### PR TITLE
interpretClosure: return

### DIFF
--- a/interpreter.cc
+++ b/interpreter.cc
@@ -578,7 +578,7 @@ Obj ClosureDecl::interpretClosure(Interpreter::Context &c, Closure *self,
 	// If we now have a compiled version, call it
 	if (compiledClosure)
 	{
-		callCompiledClosure(compiledClosure, self, args,
+		return callCompiledClosure(compiledClosure, self, args,
 				parameters->arguments.objects().size());
 	}
 	// Create a new symbol table for this closure


### PR DESCRIPTION
I believe that `ClosureDecl::interpretClosure` should return after calling the compiled version, just as `ClosureDecl::interpretMethod` does. Otherwise whenever `compiledClosure` exists, the code will essentially be executed twice: first the compiled code is called and then the closure is executed  within the interpreter.
