### PR TITLE
Bug fix in method name to selector mapping.

### DIFF
--- a/runtime.cc
+++ b/runtime.cc
@@ -535,7 +535,7 @@ Selector lookupSelector(const std::string &str)
 		}
 	}
 	// Look up the selector
-	size_t next = selectors.size();
+	size_t next = selectors.size() + 1;
 	Selector &sel = selectors[str];
 	// If it doesn't exist, register it
 	if (sel == 0)


### PR DESCRIPTION
Fixed a bug where the last static method name and the first user defined method name were assigned the same selector.

The bug can be observed by the following code, where the current implementation would print 1:

```
class Test
{
	func write()
	{
		return 1;
	}
	func two()
	{
		return 2;
	}
}

var test = new Test;
test.two().dump();
```