### PR TITLE
Fix an issue with whitespace being trimmed in string literals

### DIFF
--- a/grammar.hh
+++ b/grammar.hh
@@ -115,7 +115,7 @@ struct MysoreScriptGrammar
 	/**
 	 * Strings any characters, enclosed in quotes.
 	 */
-	Rule string  = '"' >> string_body >> '"';
+	Rule string  = term('"' >> string_body >> '"');
 	/**
 	 * Letters - valid characters for the start of an identifier.
 	 */


### PR DESCRIPTION
Because string literals were not being considered as complete term, whitespace at the front and back of the string was being trimmed, resulting in:
```javascript
("Hello," + " world!\n").dump();
```
Giving output of: `Hello,world!\n`.