### PR TITLE
Add error messages when accessing undefined variables

### DIFF
--- a/interpreter.cc
+++ b/interpreter.cc
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <iostream>
 #include "parser.hh"
 
 using namespace AST;
@@ -451,7 +452,13 @@ Obj VarRef::evaluateExpr(Interpreter::Context &c)
 {
 	// Get the address of the variable corresponding to this symbol and then
 	// load the object stored there.
-	return *c.lookupSymbol(name);
+	Obj *address = c.lookupSymbol(name);
+	if (address != nullptr)
+	{
+		return *address;
+	}
+	std::cerr << std::endl << "ERROR: " << name << " is not defined." << std::endl;
+	return nullptr;
 }
 
 void ClosureDecl::check()

--- a/interpreter.cc
+++ b/interpreter.cc
@@ -521,6 +521,15 @@ Obj ClosureDecl::evaluateExpr(Interpreter::Context &c)
 	for (auto &var : boundVars)
 	{
 		C->boundVars[i++] = *c.lookupSymbol(var);
+		Obj *address = c.lookupSymbol(var);
+		if (address != nullptr)
+		{
+			C->boundVars[i++] = *address;
+		}
+		else
+		{
+			std::cerr << "ERROR: " << var << " is not defined." << std::endl;
+		}
 	}
 	return reinterpret_cast<Obj>(C);
 }


### PR DESCRIPTION
Previously, accessing an undefined variable would cause a null pointer
to be dereferenced. Here, a warning message is printed instead, and the
null value is propagated.