### PR TITLE
Fix a bug where all local variables are global

### DIFF
--- a/interpreter.cc
+++ b/interpreter.cc
@@ -546,7 +546,7 @@ Obj ClosureDecl::interpretMethod(Interpreter::Context &c, Method *mth, Obj self,
 		c.setSymbol(*param.get(), &args[i++]);
 	}
 	i = 0;
-	Obj *locals = new Obj[decls.size()];
+	Obj *locals = gcAlloc<Obj>(decls.size() * sizeof(Obj));
 	for (auto &decl : decls)
 	{
 		// Ensure local variables have allocated storage, so that they're not
@@ -573,7 +573,6 @@ Obj ClosureDecl::interpretMethod(Interpreter::Context &c, Method *mth, Obj self,
 	c.isReturning = false;
 	// Pop the symbols off the symbol table (very important, as they reference
 	// our stack frame!)
-	delete[] locals;
 	c.popSymbols();
 	return retVal;
 }
@@ -613,7 +612,7 @@ Obj ClosureDecl::interpretClosure(Interpreter::Context &c, Closure *self,
 		c.setSymbol(bound, &self->boundVars[i++]);
 	}
 	i = 0;
-	Obj *locals = new Obj[decls.size()];
+	Obj *locals = gcAlloc<Obj>(decls.size() * sizeof(Obj));
 	for (auto &decl : decls)
 	{
 		// Ensure local variables have allocated storage, so that they're not
@@ -630,7 +629,6 @@ Obj ClosureDecl::interpretClosure(Interpreter::Context &c, Closure *self,
 	c.isReturning = false;
 	// Pop the symbols off the symbol table (very important, as they reference
 	// our stack frame!)
-	delete[] locals;
 	c.popSymbols();
 	return retVal;
 }

--- a/interpreter.cc
+++ b/interpreter.cc
@@ -545,6 +545,14 @@ Obj ClosureDecl::interpretMethod(Interpreter::Context &c, Method *mth, Obj self,
 	{
 		c.setSymbol(*param.get(), &args[i++]);
 	}
+	i = 0;
+	Obj *locals = new Obj[decls.size()];
+	for (auto &decl : decls)
+	{
+		// Ensure local variables have allocated storage, so that they're not
+		// treated as global variables.
+		c.setSymbol(decl, &locals[i++]);
+	}
 	Obj cmdObj = createSmallInteger(sel);
 	// Add self and cmd (receiver and selector) to the symbol table
 	c.setSymbol("self", &self);
@@ -565,6 +573,7 @@ Obj ClosureDecl::interpretMethod(Interpreter::Context &c, Method *mth, Obj self,
 	c.isReturning = false;
 	// Pop the symbols off the symbol table (very important, as they reference
 	// our stack frame!)
+	delete[] locals;
 	c.popSymbols();
 	return retVal;
 }
@@ -603,6 +612,14 @@ Obj ClosureDecl::interpretClosure(Interpreter::Context &c, Closure *self,
 		// Bound variables are stored within the closure object
 		c.setSymbol(bound, &self->boundVars[i++]);
 	}
+	i = 0;
+	Obj *locals = new Obj[decls.size()];
+	for (auto &decl : decls)
+	{
+		// Ensure local variables have allocated storage, so that they're not
+		// treated as global variables.
+		c.setSymbol(decl, &locals[i++]);
+	}
 	// Interpret the body
 	body->interpret(c);
 	// Return the return value.  Make sure it's set back to nullptr after we've
@@ -613,6 +630,7 @@ Obj ClosureDecl::interpretClosure(Interpreter::Context &c, Closure *self,
 	c.isReturning = false;
 	// Pop the symbols off the symbol table (very important, as they reference
 	// our stack frame!)
+	delete[] locals;
 	c.popSymbols();
 	return retVal;
 }


### PR DESCRIPTION
Previously, because local variables in functions and methods weren’t
being allocated any memory, they were instead being treated as global
variables.