### PR TITLE
Fix not being able to return out of while loops

### DIFF
--- a/interpreter.cc
+++ b/interpreter.cc
@@ -640,7 +640,7 @@ void IfStatement::interpret(Interpreter::Context &c)
 }
 void WhileLoop::interpret(Interpreter::Context &c)
 {
-	while ((reinterpret_cast<intptr_t>(condition->evaluate(c))) & ~7)
+	while (!c.isReturning && (reinterpret_cast<intptr_t>(condition->evaluate(c))) & ~7)
 	{
 		body->interpret(c);
 	}


### PR DESCRIPTION
Previously, returning out of a while loop, without also making sure
that the loop condition would be satisfied, would result in an infinite
loop. Undesirable, to say the least.