### PR TITLE
Fix operator table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ invoking the following methods:
 
 Operator | Method
 ---------|-------
-   +     |  add
-   -     |  sub
-   *     |  mul
-   /     |  div
+   `+`   |  add
+   `-`   |  sub
+   `*`   |  mul
+   `/`   |  div
 
 When used on values of the `Number` type, they have their conventional
 meanings.  


### PR DESCRIPTION
It's possible this is just a problem with GitHub's renderer, but as that's the most common place for people to see it, it seems wise to change it there.