### PR TITLE
Flush stdout/stderr after printing/dumping

### DIFF
--- a/runtime.cc
+++ b/runtime.cc
@@ -246,6 +246,7 @@ Obj NumberPrint(Obj str, Selector sel)
 Obj StringDump(String *str, Selector sel)
 {
 	fwrite(str->characters, getInteger(str->length), 1, stderr);
+	fflush(stderr);
 	return nullptr;
 }
 /**
@@ -254,6 +255,7 @@ Obj StringDump(String *str, Selector sel)
 Obj StringPrint(String *str, Selector sel)
 {
 	fwrite(str->characters, getInteger(str->length), 1, stdout);
+	fflush(stdout);
 	return nullptr;
 }
 /**


### PR DESCRIPTION
Buffered output is confusing in a language that doesn’t support
manually flushing output, so the simplest solution is to always flush
MysoreScript output.

This prevents confusion with strings not being printed immediately sometimes due to the buffering.