### PR TITLE
Allow underscores to be used in identifiers

### DIFF
--- a/grammar.hh
+++ b/grammar.hh
@@ -124,7 +124,7 @@ struct MysoreScriptGrammar
 	 * Identifiers are a letter followed by zero or more alphanumeric
 	 * characters.
 	 */
-	Rule identifier   = term(letter >> *(letter | digit));
+	Rule identifier   = term((letter | '_') >> *(letter | digit | '_'));
 	/**
 	 * Argument list.  Zero or more comma-separated arguments, wrapped in
 	 * brackets.


### PR DESCRIPTION
Most languages allow underscores in identifier names, so it’s convenient to allow it in MysoreScript too.