### PR TITLE
Allow expressionless return statements

### DIFF
--- a/ast.hh
+++ b/ast.hh
@@ -722,7 +722,7 @@ namespace AST
 		/**
 		 * The expression that is returned.
 		 */
-		ASTPtr<Expression> expr;
+		ASTPtr<Expression, true/*optional*/> expr;
 		/**
 		 * Interpret the returned expression and then indicate in the context
 		 * that we have hit a return statement and so should stop interpreting.
@@ -738,7 +738,10 @@ namespace AST
 		void collectVarUses(std::unordered_set<std::string> &decls,
 		                    std::unordered_set<std::string> &uses) override
 		{
-			expr->collectVarUses(decls, uses);
+			if (expr != nullptr)
+			{
+				expr->collectVarUses(decls, uses);
+			}
 		}
 	};
 	/**

--- a/compiler.cc
+++ b/compiler.cc
@@ -508,9 +508,16 @@ void Statements::compile(Compiler::Context &c)
 
 void Return::compile(Compiler::Context &c)
 {
-	// Insert a return instruction with the correct value
-	Value *ret = expr->compileExpression(c);
-	c.B.CreateRet(getAsObject(c, ret));
+	if (expr != nullptr)
+	{
+		// Insert a return instruction with the correct value
+		Value *ret = expr->compileExpression(c);
+		c.B.CreateRet(getAsObject(c, ret));
+	}
+	else
+	{
+		c.B.CreateRet(ConstantPointerNull::get(c.ObjPtrTy));
+	}
 	// Clear the insert point so nothing else tries to insert instructions after
 	// the basic block terminator
 	c.B.ClearInsertionPoint();

--- a/grammar.hh
+++ b/grammar.hh
@@ -187,7 +187,7 @@ struct MysoreScriptGrammar
 	/**
 	 * A return statement.
 	 */
-	Rule ret          = "return"_E >> expression >> ';';
+	Rule ret          = "return"_E >> -expression >> ';';
 	/**
 	 * An if statement, with a condition in brackets followed by the body in
 	 * braces.

--- a/interpreter.cc
+++ b/interpreter.cc
@@ -691,7 +691,7 @@ void Return::interpret(Interpreter::Context &c)
 {
 	// Evaluate the returned expression and then indicate in the interpreter
 	// context that we're returning.
-	c.retVal = expr->evaluate(c);
+	c.retVal = expr != nullptr ? expr->evaluate(c) : nullptr;
 	c.isReturning = true;
 }
 


### PR DESCRIPTION
This removes the restriction that return statements have to return
values, as this restriction is not necessary for functions that have
side-effects, as a control-flow mechanism.