### PR TITLE
Extend the argument limit to 10

### DIFF
--- a/runtime.cc
+++ b/runtime.cc
@@ -636,6 +636,7 @@ Obj callCompiledMethod(CompiledMethod m, Obj receiver, Selector sel, Obj *args,
 	{
 		default:
 			assert(0 && "Too many arguments!");
+			std::cerr << "ERROR: cannot call a method with more than 10 arguments." << std::endl;
 			return nullptr;
 		case 0:
 			return (reinterpret_cast<Obj(*)(Obj, Selector)>(m))(receiver, sel);
@@ -648,8 +649,29 @@ Obj callCompiledMethod(CompiledMethod m, Obj receiver, Selector sel, Obj *args,
 			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj)>(m))(receiver, sel,
 					args[0], args[1], args[2]);
 		case 4:
-			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj)>(m))(receiver,
-					sel, args[0], args[1], args[2], args[3]);
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj)>(m))(receiver, sel,
+					args[0], args[1], args[2], args[3]);
+		case 5:
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj, Obj)>(m))(receiver,
+					sel, args[0], args[1], args[2], args[3], args[4]);
+		case 6:
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj, Obj, Obj)>(m))(
+					receiver, sel, args[0], args[1], args[2], args[3], args[4], args[5]);
+		case 7:
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj, Obj, Obj, Obj)>(m))(
+					receiver, sel, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+		case 8:
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj)>
+					(m))(receiver, sel, args[0], args[1], args[2], args[3], args[4], args[5],
+					args[6], args[7]);
+		case 9:
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj,
+					Obj)>(m))(receiver, sel, args[0], args[1], args[2], args[3], args[4], args[5],
+					args[6], args[7], args[8]);
+		case 10:
+			return (reinterpret_cast<Obj(*)(Obj, Selector, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj,
+					Obj, Obj)>(m))(receiver, sel, args[0], args[1], args[2], args[3], args[4],
+					args[5], args[6], args[7], args[8], args[9]);
 	}
 }
 
@@ -660,6 +682,7 @@ Obj callCompiledClosure(ClosureInvoke m, Closure *receiver, Obj *args,
 	{
 		default:
 			assert(0 && "Too many arguments!");
+			std::cerr << "ERROR: cannot call a closure with more than 10 arguments." << std::endl;
 			return nullptr;
 		case 0:
 			return (reinterpret_cast<Obj(*)(Closure*)>(m))(receiver);
@@ -668,11 +691,32 @@ Obj callCompiledClosure(ClosureInvoke m, Closure *receiver, Obj *args,
 		case 2:
 			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj)>(m))(receiver, args[0], args[1]);
 		case 3:
-			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj)>(m))(receiver, args[0], args[1],
-					args[2]);
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj)>(m))(receiver, args[0],
+					args[1], args[2]);
 		case 4:
 			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj)>(m))(receiver, args[0],
 					args[1], args[2], args[3]);
+		case 5:
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj, Obj)>(m))(receiver,
+					args[0], args[1], args[2], args[3], args[4]);
+		case 6:
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj, Obj, Obj)>(m))(receiver,
+					args[0], args[1], args[2], args[3], args[4], args[5]);
+		case 7:
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj, Obj, Obj, Obj)>(m))(
+					receiver, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+		case 8:
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj)>(m))(
+					receiver, args[0], args[1], args[2], args[3], args[4], args[5], args[6],
+					args[7]);
+		case 9:
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj)>
+					(m))(receiver, args[0], args[1], args[2], args[3], args[4], args[5], args[6],
+					args[7], args[8]);
+		case 10:
+			return (reinterpret_cast<Obj(*)(Closure*, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj, Obj,
+					Obj)>(m))(receiver, args[0], args[1], args[2], args[3], args[4], args[5],
+					args[6], args[7], args[8], args[9]);
 	}
 }
 


### PR DESCRIPTION
The argument array already had a length of 10, but methods with more
than 4 arguments previously failed silently. Now there’s an error, as
well as an extended limit.